### PR TITLE
Fix signing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See the [examples](./examples/) folder if you're looking for a complete sample p
 ## Examples
 
 * [Whoami](./examples/whoami/): example showcasing API request signing in its simplest form
-* [Signing](./examples/whoami/): example showcasing wallet creation and ETH message signing
+* [Signing](./examples/signing/): example showcasing wallet creation and ETH message signing
 
 ## Using Turnkey in your Rails projects
 


### PR DESCRIPTION
duplicated whoami link, the second one should go to /signing