### PR TITLE
Avoid bundling untracked files in gem publishing

### DIFF
--- a/turnkey_client/turnkey_client.gemspec
+++ b/turnkey_client/turnkey_client.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
+  s.files         = `git ls-files -z`.split("\x0")
   s.executables   = []
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
Ok so, hilarious and sad bug: I have been publishing the Ruby SDK from my machine for a long time and because of that I have a local `turnkey_client` folder which contains previously built artifact. 

The issue, now obvious in retrospect: we bundle EVERYTHING in `turnkey_client` to bundle the gem for release:
https://github.com/tkhq/ruby-sdk/blob/33f6e21329c7935051ea98b265427d81e6258829/turnkey_client/turnkey_client.gemspec#L34

This means...the gems double their size every time we release. Recently we finally caught this because the size is ridiculous:

<img width="299" height="284" alt="image" src="https://github.com/user-attachments/assets/775dd599-a197-4482-8174-1e20f14dea0a" />

Turns out exponential growth hurts pretty quickly...

Fix: only bundle files git knows about!